### PR TITLE
Update cli.py

### DIFF
--- a/sbommerge/cli.py
+++ b/sbommerge/cli.py
@@ -224,7 +224,7 @@ def main(argv=None):
             # If package version differ, don't merge
             for package2 in packages2:
                 if package2["name"] == package["name"]:
-                    if package["version"] != package2["version"]:
+                    if "version" in package.keys() and "version" in package2.keys() and package["version"] != package2["version"]:
                         print(
                             f"[ERROR] Version mismatch for"
                             f" {package['name']}"


### PR DESCRIPTION
Check for "version" key to avoid a KeyError.

This is the error I was seeing:

![image](https://github.com/anthonyharrison/sbommerge/assets/97547996/cabaedc7-054d-4264-aba9-d446cdeceb00)


And the proposed change solved the issue for me.  This is because the SDPX SBOM I was working with had some packages that were missing version information. By going to the "else" statement on line 235 in the event that "version" is missing from the package information, it instead compares each parameter within the package.